### PR TITLE
Fix GHC 8.0.2 build

### DIFF
--- a/src/Test/QuickCheck/Combinators.hs
+++ b/src/Test/QuickCheck/Combinators.hs
@@ -38,7 +38,8 @@ newtype AtLeast (n :: Nat) t a = AtLeast
   } deriving (Show, Read, Eq, Ord, Enum, Data, Typeable, Generic, Functor
              , Applicative, Monad, Foldable, Traversable, Monoid)
 
-instance ( UnfoldableR p t
+instance {-# OVERLAPPABLE #-}
+         ( UnfoldableR p t
          , Monoid (t a)
          , Arbitrary a
          , KnownNat n
@@ -50,7 +51,8 @@ instance ( UnfoldableR p t
     ts <- fromMaybe mempty . fromList <$> replicateM k arbitrary
     return . AtLeast $ ts
 
-instance ( Arbitrary a
+instance {-# OVERLAPPING #-}
+         ( Arbitrary a
          , Ord a
          , UnfoldableR p []
          , p a
@@ -68,7 +70,8 @@ newtype AtMost (n :: Nat) t a = AtMost
   } deriving (Show, Read, Eq, Ord, Enum, Data, Typeable, Generic, Functor
              , Applicative, Monad, Foldable, Traversable, Monoid)
 
-instance ( UnfoldableR p t
+instance {-# OVERLAPPABLE #-}
+         ( UnfoldableR p t
          , Monoid (t a)
          , Arbitrary a
          , KnownNat m
@@ -80,7 +83,8 @@ instance ( UnfoldableR p t
     ts <- fromMaybe mempty . fromList <$> replicateM k arbitrary
     return . AtMost $ ts
 
-instance ( Arbitrary a
+instance {-# OVERLAPPING #-}
+         ( Arbitrary a
          , Ord a
          , UnfoldableR p []
          , p a
@@ -98,7 +102,8 @@ newtype Between (n :: Nat) (m :: Nat) t a = Between
   } deriving (Show, Read, Eq, Ord, Enum, Data, Typeable, Generic, Functor
              , Applicative, Monad, Foldable, Traversable, Monoid)
 
-instance ( UnfoldableR p t
+instance {-# OVERLAPPABLE #-}
+         ( UnfoldableR p t
          , Monoid (t a)
          , Arbitrary a
          , KnownNat n
@@ -112,7 +117,8 @@ instance ( UnfoldableR p t
     ts <- fromMaybe mempty . fromList <$> replicateM k arbitrary
     return . Between $ ts
 
-instance ( Arbitrary a
+instance {-# OVERLAPPING #-}
+         ( Arbitrary a
          , Ord a
          , KnownNat n
          , UnfoldableR p []


### PR DESCRIPTION
This library fails to build with GHC 8.0.2 because it mistakenly doesn't annotate its overlapping instances with `OVERLAPPING` annotations (8.0.2 is more strict about this than previous versions, see https://ghc.haskell.org/trac/ghc/ticket/12881). Luckily, it's easy to fix.